### PR TITLE
fix: action workflow failure due to indentation of EOF content as per…

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -59,7 +59,7 @@ EOF
             fi
 
           # --- CASE 3: FIRST PR MERGED ---
-          elif [[ "${{ github.event.pull_request.merged }}" == "true" ]]; then
+          elif [[ "${{ github.event_name }}" == "pull_request_target" && "${{ github.event.pull_request.merged }}" == "true" ]]; then
             COUNT=$(curl -s -H "Authorization: Bearer $GH_TOKEN" "https://api.github.com/search/issues?q=author:$USER_LOGIN+repo:$REPO+type:pr+is:merged" | jq '.total_count')
             if [ "$COUNT" -eq 1 ]; then
               cat <<EOF > body.txt


### PR DESCRIPTION
fixing action workflow by removing the indentation of content b/w cat <<EOF & EOF, as last failed workflow was probbaly due to thsi indentation which might have kept with intention to match yaml structure, but it failed the bash formatting, locally

also added `${{ github.event.pull_request.merged }}` to the merge check to ensure it only fires when the button is actually clicked